### PR TITLE
Improve API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,114 @@
 # arha-split-text
 
-A react component to split passed in `children`-prop into word-spans and each word-span into character-spans. This lets developers do f.e. word / character based animations for text-elements.
+A react component to split passed in `children`-prop into word elements and each word into character elements. This lets developers do f.e. word / character based animations for a text.
 
 ## Example usage
 
-For following React app:
-
-```
+``` jsx
 import React from "react";
-import SplitText from "arha-split-text";
+import { SplitText } from "arha-split-text";
 
 function App() {
-  return <SplitText>Edit src/App.js</SplitText>;
+  return <SplitText>foo bar</SplitText>;
 }
 
 export default App;
+
+// output:
+//  <div>
+//    <div>
+//      <div>f</div>
+//      <div>o</div>
+//      <div>o</div>
+//    </div>
+//    <div></div>
+//    <div>
+//      <div>b</div>
+//      <div>a</div>
+//      <div>r</div>
+//    </div>
+//  </div>
+//
 ```
 
-an output would be:
+SplitText also provides additional props, so developers can have more control over the output
 
-```
-<div
-  aria-label="Edit src/App.js"
-  class="c-split-text"
-  style="display: inline-flex; flex-wrap: wrap;"
->
-  <span
-    aria-hidden="true"
-    class="word"
-    data-word="Edit"
-    style="display: inline-block;"
-  >
-    <span class="char" aria-hidden="true">
-      E
-    </span>
-    <span class="char" aria-hidden="true">
-      d
-    </span>
-    <span class="char" aria-hidden="true">
-      i
-    </span>
-    <span class="char" aria-hidden="true">
-      t
-    </span>
-    <span aria-hidden="true" class="space" style="display: inline-block;">
-      &nbsp;
-    </span>
+```jsx
+import React from "react";
+import { SplitText } from "./arha-split-text"
+
+/**
+ * Example word component
+ */
+const Word = ({ children, i }) => (
+  <span className={`word word-${i}`}>
+    {children}
   </span>
-  <span
-    aria-hidden="true"
-    class="word"
-    data-word="src/App.js"
-    style="display: inline-block;"
-  >
-    <span class="char" aria-hidden="true">
-      s
-    </span>
-    <span class="char" aria-hidden="true">
-      r
-    </span>
-    <span class="char" aria-hidden="true">
-      c
-    </span>
-    <span class="char" aria-hidden="true">
-      /
-    </span>
-    <span class="char" aria-hidden="true">
-      A
-    </span>
-    <span class="char" aria-hidden="true">
-      p
-    </span>
-    <span class="char" aria-hidden="true">
-      p
-    </span>
-    <span class="char" aria-hidden="true">
-      .
-    </span>
-    <span class="char" aria-hidden="true">
-      j
-    </span>
-    <span class="char" aria-hidden="true">
-      s
-    </span>
+)
+
+/**
+ * Example Space component
+ */
+const Space = () => "\u00A0"
+
+/**
+ * Example Char component
+ */
+const Char = ({ children, i }) => (
+  <span className={`char char-${i}`}>
+    {children}
   </span>
-</div>
+)
+
+function App() {
+  return (
+    <SplitText
+      ContainerElement="h1" // I can be a function component as well 
+      WordElement={Word}
+      CharElement={Char}
+      SpaceElement={Space}
+      // rest are set to container element
+      className="my-cool-split-text"
+    >
+      awesome component   
+    </SplitText>
+  )
+}
+
+export default App;
+
+//  <h1 class="my-cool-split-text">
+//    <span class="word word-0">
+//      <span class="char char-0">a</span>
+//      <span class="char char-1">w</span>
+//      <span class="char char-2">e</span>
+//      <span class="char char-3">s</span>
+//      <span class="char char-4">o</span>
+//      <span class="char char-5">m</span>
+//      <span class="char char-6">e</span>
+//    </span>
+//    &nbsp;
+//    <span class="word word-1">
+//      <span class="char char-0">c</span>
+//      <span class="char char-1">o</span>
+//      <span class="char char-2">m</span>
+//      <span class="char char-3">p</span>
+//      <span class="char char-4">o</span>
+//      <span class="char char-5">n</span>
+//      <span class="char char-6">e</span>
+//      <span class="char char-7">n</span>
+//      <span class="char char-8">t</span>
+//    </span>
+//  </h1>
 ```
 
 ## Props
+| Prop                | Description                                                     | Type                          |
+| ---                 | ---                                                             | ---                           |
+| `children`          | string needed to be split                                       | string                        |
+| `ContainerElement`  | overrides default container element (by default `div`)          | string or function component  |
+| `WordElement`       | overrides default word element (by default `div`)               | string or function component  |
+| `CharElement`       | overrides default char element (by default `div`)               | string or function component  |
+| `SpaceElement`      | overrides default space element (by default `div` with `{" "}`) | string or function component  |
+| `...rest`           | rest of the props are set to container element                  | go wild                       |
 
-| Prop key       | Expected Type | Description                                                                             |
-| -------------- | ------------- | --------------------------------------------------------------------------------------- |
-| children       | string        | text wanted to be split                                                                 |
-| className      | string        | className passed to wrapper element                                                     |
-| type           | string        | wrapper element's type, f.e. `"h1"` or `"p"`. By default `div`                          |
-| wordClassName  | string        | className set to each word element                                                      |
-| wordType       | string        | word elements' type, f.e. `"h1"` or `"p"`. By default `span`                            |
-| charClassName  | string        | className set to each character element                                                 |
-| charType       | string        | char elements' type, f.e. `"h1"` or `"p"`. By default `span`                            |
-| spaceClassName | string        | className set to each space element                                                     |
-| spaceType      | string        | space elements' type, f.e. `"h1"` or `"p"`. By default `span`                           |
-| spaceHTML      | string        | a character that is used as a text content for each space element. by default `&nbsp;`  |
-| wordRefs       | object        | `useRef()`'s returned object. Note: use empty array when initializing the default value |
-| charRefs       | object        | `useRef()`'s returned object. Note: use empty array when initializing the default value |
-| ...rest        |               | rest of the props are spread to wrapper element                                         |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,6 @@ export default App;
 | `ContainerElement`  | overrides default container element (by default `div`)          | string or function component  |
 | `WordElement`       | overrides default word element (by default `div`)               | string or function component  |
 | `CharElement`       | overrides default char element (by default `div`)               | string or function component  |
-| `SpaceElement`      | overrides default space element (by default `div` with `{" "}`) | string or function component  |
+| `SpaceElement`      | overrides default space element (by default `<div>{" "}</div>`) | string or function component  |
 | `...rest`           | rest of the props are set to container element                  | go wild                       |
 

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1,80 +1,217 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SplitText-component renders correctly with foo children-prop 1`] = `
-<div
-  aria-label="foo"
-  className="c-split-text "
-  style={
-    Object {
-      "display": "block",
-    }
-  }
+exports[`SplitText-component CharElement-prop has access to current character's index inside the word if its a function component 1`] = `
+<div>
+  <div>
+    <span>
+      <span>
+        current index of the character inside the word: 0
+      </span>
+      f
+    </span>
+    <span>
+      <span>
+        current index of the character inside the word: 1
+      </span>
+      o
+    </span>
+    <span>
+      <span>
+        current index of the character inside the word: 2
+      </span>
+      o
+    </span>
+  </div>
+</div>
+`;
+
+exports[`SplitText-component Doesn't crash with no props 1`] = `null`;
+
+exports[`SplitText-component WordElement-prop has access to current word index if its a function component 1`] = `
+<div>
+  <span>
+    <p>
+      I'm current word's index 0
+    </p>
+    <div>
+      f
+    </div>
+    <div>
+      o
+    </div>
+    <div>
+      o
+    </div>
+  </span>
+  <div>
+     
+  </div>
+  <span>
+    <p>
+      I'm current word's index 1
+    </p>
+    <div>
+      b
+    </div>
+    <div>
+      a
+    </div>
+    <div>
+      r
+    </div>
+  </span>
+  <div>
+     
+  </div>
+  <span>
+    <p>
+      I'm current word's index 2
+    </p>
+    <div>
+      b
+    </div>
+    <div>
+      a
+    </div>
+    <div>
+      z
+    </div>
+  </span>
+</div>
+`;
+
+exports[`SplitText-component renders with children prop 1`] = `
+<div>
+  <div>
+    <div>
+      f
+    </div>
+    <div>
+      o
+    </div>
+    <div>
+      o
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SplitText-component sets rest of the props to wrapper element 1`] = `
+<p
+  aria-label="first second third"
+  className="foo"
+  id="1"
+  onclick={[Function]}
 >
   <span
-    aria-hidden={true}
-    className="word "
-    data-word="foo"
-    style={
-      Object {
-        "display": "inline-flex",
-      }
-    }
+    i={0}
   >
     <span
-      aria-hidden={true}
-      className="char "
+      i={0}
       key="0"
     >
       f
     </span>
     <span
-      aria-hidden={true}
-      className="char "
+      i={1}
       key="1"
+    >
+      i
+    </span>
+    <span
+      i={2}
+      key="2"
+    >
+      r
+    </span>
+    <span
+      i={3}
+      key="3"
+    >
+      s
+    </span>
+    <span
+      i={4}
+      key="4"
+    >
+      t
+    </span>
+  </span>
+  <span />
+  <span
+    i={1}
+  >
+    <span
+      i={0}
+      key="0"
+    >
+      s
+    </span>
+    <span
+      i={1}
+      key="1"
+    >
+      e
+    </span>
+    <span
+      i={2}
+      key="2"
+    >
+      c
+    </span>
+    <span
+      i={3}
+      key="3"
     >
       o
     </span>
     <span
-      aria-hidden={true}
-      className="char "
-      key="2"
+      i={4}
+      key="4"
     >
-      o
+      n
+    </span>
+    <span
+      i={5}
+      key="5"
+    >
+      d
     </span>
   </span>
-</div>
-`;
-
-exports[`SplitText-component renders with no props 1`] = `
-<ForwardRef
-  charClassName=""
-  charRefs={
-    Object {
-      "current": Array [],
-    }
-  }
-  charType="span"
-  className=""
-  spaceClassName=""
-  spaceHTML="&nbsp;"
-  spaceType="span"
-  type="div"
-  wordClassName=""
-  wordRefs={
-    Object {
-      "current": Array [],
-    }
-  }
-  wordType="span"
->
-  <div
-    aria-label=""
-    className="c-split-text "
-    style={
-      Object {
-        "display": "block",
-      }
-    }
-  />
-</ForwardRef>
+  <span />
+  <span
+    i={2}
+  >
+    <span
+      i={0}
+      key="0"
+    >
+      t
+    </span>
+    <span
+      i={1}
+      key="1"
+    >
+      h
+    </span>
+    <span
+      i={2}
+      key="2"
+    >
+      i
+    </span>
+    <span
+      i={3}
+      key="3"
+    >
+      r
+    </span>
+    <span
+      i={4}
+      key="4"
+    >
+      d
+    </span>
+  </span>
+</p>
 `;

--- a/index.js
+++ b/index.js
@@ -1,171 +1,54 @@
-const { createElement, Fragment, forwardRef, useEffect } = require("react")
-const PropTypes = require("prop-types")
+import PropTypes from "prop-types"
+import React, { Fragment } from "react"
 
-const SplitText = forwardRef((props, ref) => {
-	const {
-		children,
+export const SplitText = ({ children, ContainerElement, WordElement, CharElement, SpaceElement, ...rest }) => {
+  if (!children) return null
 
-		className,
-		type,
+  const words = children.split(" ")
 
-		wordClassName,
-		wordType,
-
-		charClassName,
-		charType,
-
-		spaceClassName,
-		spaceType,
-		spaceHTML,
-
-		wordRefs,
-		charRefs,
-
-		...rest
-	} = props
-
-	const wrapperCN = `c-split-text ${className}`
-	const wrapperProps = {
-		"aria-label": children,
-		className: wrapperCN,
-		ref,
-		style: {
-			display: "block"
-		},
-		...rest
-	}
-
-	const wordDefaultCN = "word"
-	const wordProps = {
-		"aria-hidden": true,
-		className: `${wordDefaultCN} ${wordClassName}`,
-		style: {
-			display: "inline-flex"
-		}
-	}
-
-	const charDefaultCN = "char"
-	const charProps = {
-		className: `${charDefaultCN} ${charClassName}`,
-		"aria-hidden": true
-	}
-
-	const spaceCN = `space ${spaceClassName}`
-	// space is rendered using this element
-	const spaceElement = createElement(
-		spaceType,
-		{
-			"aria-hidden": true,
-			className: spaceCN,
-			dangerouslySetInnerHTML: { __html: spaceHTML },
-			style: { display: "inline-block" }
-		},
-		null
-	)
-
-	// sending refs to parent component
-	useEffect(() => {
-		if (!ref || !ref.current) return
-
-		const wrapper = ref.current
-		const words = Array.from(wrapper.querySelectorAll(`.${wordDefaultCN}`))
-		if (words.length === 0) return
-		wordRefs.current = words
-
-		const chars = Array.from(wrapper.querySelectorAll(`.${charDefaultCN}`))
-		if (chars.length === 0) return
-		charRefs.current = chars
-
-		// clean parent component's refs on dismount
-		return () => {
-			wordRefs.current = []
-			charRefs.current = []
-		}
-	}, [ref, wordRefs, charRefs, wordDefaultCN, charDefaultCN])
-
-	// wrapper element
-	return createElement(
-		type,
-		wrapperProps,
-		children.split(" ").map((word, i, words) => {
-			if (word === "") return ""
-
-			const space = i === words.length - 1 ? null : spaceElement
-
-			return createElement(
-				Fragment,
-				{
-					key: i
-				},
-				createElement(
-					wordType,
-					{
-						...wordProps,
-						"data-word": word
-					},
-					word.split("").map((char, i) =>
-						createElement(
-							charType,
-							{
-								...charProps,
-								key: i
-							},
-							char
-						)
-					),
-					space
-				)
-			)
-		})
-	)
-})
+  return (
+    <ContainerElement {...rest}>
+      {words.map((word, i) => (
+        <Fragment key={i}>
+          <WordElement i={i}>
+            {word.split("").map((char, j) => (
+              <CharElement key={j} i={j}>
+                {char}
+              </CharElement>
+            ))}
+          </WordElement>
+          {i !== words.length - 1 && (<SpaceElement />)}
+        </Fragment>
+      ))}
+    </ContainerElement>
+  )
+} 
 
 SplitText.defaultProps = {
-	children: "",
-
-	className: "",
-	type: "div",
-
-	wordClassName: "",
-	wordType: "span",
-
-	charClassName: "",
-	charType: "span",
-
-	spaceClassName: "",
-	spaceType: "span",
-	spaceHTML: "&nbsp;",
-
-	wordRefs: {
-		current: []
-	},
-	charRefs: {
-		current: []
-	}
+  className: undefined,
+  children: null,
+  ContainerElement: "div",
+  WordElement: "div",
+  CharElement: "div",
+  SpaceElement: () => <div>{" "}</div>
 }
 
 SplitText.propTypes = {
-	children: PropTypes.string,
-
-	className: PropTypes.string,
-	type: PropTypes.string,
-
-	wordClassName: PropTypes.string,
-	wordType: PropTypes.string,
-
-	charClassName: PropTypes.string,
-	charType: PropTypes.string,
-
-	spaceClassName: PropTypes.string,
-	spaceType: PropTypes.string,
-	spaceHTML: PropTypes.string,
-
-	wordRefs: PropTypes.shape({
-		current: PropTypes.array
-	}),
-	charRefs: PropTypes.shape({
-		current: PropTypes.array
-	})
+  children: PropTypes.string,
+  ContainerElement: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
+  WordElement: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
+  CharElement: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
+  SpaceElement: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func
+  ]),
 }
-
-module.exports = SplitText

--- a/index.js
+++ b/index.js
@@ -25,11 +25,10 @@ export const SplitText = ({ children, ContainerElement, WordElement, CharElement
 } 
 
 SplitText.defaultProps = {
-  className: undefined,
   children: null,
-  ContainerElement: "div",
-  WordElement: "div",
-  CharElement: "div",
+  ContainerElement: ({ children }) => <div>{children}</div>,
+  WordElement: ({ children }) => <div>{children}</div>,
+  CharElement: ({ children }) => <div>{children}</div>,
   SpaceElement: () => <div>{" "}</div>
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arha-split-text",
-	"version": "1.0.8",
+	"version": "2.0.0",
 	"description": "A react component that splits passed in `children`-prop into word-spans and each word-span into character-spans. This lets developers do f.e. word / character based animations for text-elements.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This pr simplifies component's structure and logic quite a bit

v1.0.8 (previous version) worked well for the use cases in the past, but show casing it to fellow developers makes me cringe my eyes out:
- The codebase was written in commonjs, which is now changed to es6.
- It created it's sub components with `createElement` (back then I didn't know you can `const Elem = "h1"` `<Elem />`)
- The whole prop API was confusing to use.
- The component outputs properties to it's sub components that could cause side-effects in other projects.

This change gives more control to developers, so they can implement split text in their projects the way they prefer. Only drawbacks are that this a breaking change and creating out-of-the-box good example is impossible without codepen or similar tool. Maybe it can be done in the future.

